### PR TITLE
Update and rename sbom-github.md to sbom-obtain.md

### DIFF
--- a/Cybercom-Plugfest/sbom-obtain.md
+++ b/Cybercom-Plugfest/sbom-obtain.md
@@ -1,4 +1,4 @@
-# GitHub SBoM support
+# Obtain SBoM step of various use cases
 
 ## Background
 


### PR DESCRIPTION
sbom-github was orignally supposed to be for using the github API to get sbom's for projects on github. I should do that usecase as well but this got hijacked to be the classic "get sbom from device" usecase - hence the rename